### PR TITLE
update tests

### DIFF
--- a/db_test.go
+++ b/db_test.go
@@ -55,7 +55,11 @@ func TestMiniDB_Get(t *testing.T) {
 	getVal([]byte("test_key_2"))
 	getVal([]byte("test_key_3"))
 	getVal([]byte("test_key_4"))
-	getVal([]byte("test_key_5"))
+
+	_, err = db.Get([]byte("test_key_5"))
+	if err == nil {
+		t.Error("expected test_Key_5 does not exist")
+	}
 }
 
 func TestMiniDB_Del(t *testing.T) {


### PR DESCRIPTION
When running the unit test, it says TestMiniDB_Get failed the test. This is because when generating the data above, it only generates the data for test_key_{0-4}, but here it wants to get test_key_5. I'm not quite sure if it's intentional or if there's some other reason for it, maybe it would be better to handle it like I'm doing?